### PR TITLE
Add an option to disable building the tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,10 +1,12 @@
 project('spdlog', 'cpp', version : '0.16.3', license: 'MIT',
-		default_options : ['cpp_std=c++11'])
+        default_options : ['cpp_std=c++11'])
 
 inc = include_directories('include')
 
 thread_dep = dependency('threads')
 
-subdir('tests')
+if get_option('tests')
+	subdir('tests')
+endif
 
 spdlog_dep = declare_dependency(include_directories : inc, dependencies : thread_dep)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('tests', type: 'boolean', value: true, description: 'Build the unit tests')


### PR DESCRIPTION
I'm getting lots of warnings in spdlogs tests and would rather not build them at all. Not sure if this is the way to do it?